### PR TITLE
Remove signing stuff to PiPy

### DIFF
--- a/.github/workflows/cd-pipeline.yaml
+++ b/.github/workflows/cd-pipeline.yaml
@@ -92,12 +92,12 @@ jobs:
         with:
           name: python-package-distributions
           path: dist/
-      - name: Sign the dists with Sigstore
-        uses: sigstore/gh-action-sigstore-python@v2.1.1
-        with:
-          inputs: >-
-            ./dist/*.tar.gz
-            ./dist/*.whl
+      # - name: Sign the dists with Sigstore
+      #   uses: sigstore/gh-action-sigstore-python@v2.1.1
+      #   with:
+      #     inputs: >-
+      #       ./dist/*.tar.gz
+      #       ./dist/*.whl
       - name: Create GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This pull request includes changes to the continuous deployment pipeline configuration in the `.github/workflows/cd-pipeline.yaml` file. The most important change is the temporary removal of the step that signs the distributions with Sigstore.

Changes to the continuous deployment pipeline:

* [`.github/workflows/cd-pipeline.yaml`](diffhunk://#diff-9c3de87b4b648f46683c748ed127b941b22648999c0738a574e1a8828fecc5bfL95-R100): Commented out the step that uses `sigstore/gh-action-sigstore-python@v2.1.1` to sign the distributions.